### PR TITLE
Improve logic in exercise.

### DIFF
--- a/longtail.md
+++ b/longtail.md
@@ -38,7 +38,7 @@ FROM executions
 GROUP BY county"
   data-solution="SELECT
   county,
-  last_statement IS NULL AS has_last_statement,
+  last_statement IS NOT NULL AS has_last_statement,
   COUNT(*)
 FROM executions
 GROUP BY county, has_last_statement"


### PR DESCRIPTION
The definition of has_last_statement currently follows unintuitive logic, namely, that a null (nonexistent) last_statement is coded 1 and a non-null last_statement is coded 0.  I believe the logic should be reversed to better reflect the intuition around the meaning of has_last_statement, in other words, null last_statement values should be recoded 0 and non-null last_statement value should be recoded 1.