### PR TITLE
style: Set explicit input button colors

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -305,7 +305,7 @@ sql-exercise .CodeMirror {
 sql-exercise .sqlExInputArea input {
     color: black;
     margin-right: 1em;
-    background: none;
+    background: #f9f9f9;
     font-size: 0.8em;
     font-weight: 200;
     height: 2em;

--- a/css/main.css
+++ b/css/main.css
@@ -303,11 +303,12 @@ sql-exercise .CodeMirror {
 }
 
 sql-exercise .sqlExInputArea input {
+    color: black;
     margin-right: 1em;
     background: none;
-    border-radius: 4px;
     font-size: 0.8em;
     font-weight: 200;
-    border-width: thin;
     height: 2em;
+    border: thin solid black;
+    border-radius: 4px;
 }

--- a/css/rtl/rtl_main.css
+++ b/css/rtl/rtl_main.css
@@ -308,9 +308,9 @@ sql-exercise .CodeMirror {
 }
 
 sql-exercise .sqlExInputArea input {
+    color: black;
     margin-right: 1em;
     background: #f9f9f9;
-    border-radius: 4px;
     font-size: 0.8em;
     font-weight: 200;
     border: thin solid black;

--- a/css/rtl/rtl_main.css
+++ b/css/rtl/rtl_main.css
@@ -309,8 +309,10 @@ sql-exercise .CodeMirror {
 
 sql-exercise .sqlExInputArea input {
     margin-right: 1em;
-    background: none;
+    background: #f9f9f9;
     border-radius: 4px;
     font-size: 0.8em;
     font-weight: 200;
+    border: thin solid black;
+    border-radius: 4px;
 }


### PR DESCRIPTION
Kao, thanks so much for this resource - it's the best quick intro to SQL I know of and I have huge respect for the way you present serious ethical questions through the exercises 🙏 . I've recommended the book many times.

I read through again myself on iOS Safari this week and noticed that the default browser input button colors are hard to read. How would you feel about updating the styling to use explicit background and foreground colors?

 **Before**
<img width="200" src="https://github.com/zichongkao/selectstarsql/assets/32366790/eb804519-6201-41d8-b112-6213c737234e" />

 **After**
<img width="200" src="https://github.com/zichongkao/selectstarsql/assets/32366790/d16cd896-08c3-40dc-8d6b-0d254ff31e1b" />
